### PR TITLE
Refactor compileRouteTemplateWithController to accept controller name

### DIFF
--- a/src/app/home/home.spec.js
+++ b/src/app/home/home.spec.js
@@ -50,7 +50,7 @@ describe('Unit: Home', function () {
         var element, render, ctrl, scope;
         beforeEach(inject(function ($injector) {
 
-            var routeDetails = compileRouteTemplateWithController($injector, 'home');
+            var routeDetails = compileRouteTemplateWithController($injector, 'home', 'HomeCtrl');
             ctrl = routeDetails.controller;
             scope = routeDetails.scope;
 

--- a/src/assets/js/unit-test-helpers.js
+++ b/src/assets/js/unit-test-helpers.js
@@ -1,4 +1,4 @@
-function compileRouteTemplateWithController($injector, state) {
+function compileRouteTemplateWithController($injector, state, controllerName) {
     var $rootScope = $injector.get('$rootScope');
     var $templateCache = $injector.get('$templateCache');
     var $compile = $injector.get('$compile');
@@ -9,7 +9,7 @@ function compileRouteTemplateWithController($injector, state) {
     var stateDetails = $state.get(state);
     var html = $templateCache.get(stateDetails.templateUrl);
 
-    var ctrl = scope.home = $controller('HomeCtrl');
+    var ctrl = scope[state] = $controller(controllerName);
     $rootScope.$digest();
     var compileFn = $compile(angular.element('<div></div>').html(html));
 


### PR DESCRIPTION
Make compileRouteTemplateWithController more generic so it may be used in other tests
@simpulton 